### PR TITLE
feat: convert px units to rem for better accessibility

### DIFF
--- a/luckyNumberStyles.css
+++ b/luckyNumberStyles.css
@@ -13,7 +13,7 @@ html {
     margin-top: 3.2rem;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 70rem) {
     .form-container  {
         font-size: 2rem;
     }

--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,7 @@ body {
     height: 9.6rem; 
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 70rem) {
     .advice  {
         font-size: 2rem;
     }
@@ -131,7 +131,7 @@ a {
     height: 27.8rem;   
  }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 70rem) {
     .mainContainer {
         width: 25.2rem;
         height: 18rem;  
@@ -169,7 +169,7 @@ a {
         height: 8.5rem;
     }
 
-    @media screen and (max-width: 700px) {
+    @media screen and (max-width: 70rem) {
         .theCardFront img {
             width: 5rem;
             height: 5rem;


### PR DESCRIPTION
- Convert media query breakpoints from 700px to 70rem
- Maintain visual consistency with existing 10px base font-size
- Improve responsive behavior for users with custom font sizes
- All other values were already using rem units

Fixes good-first-issue: Standardize CSS units to rem